### PR TITLE
Logistic edit

### DIFF
--- a/Missionframework/kp_liberation_config.sqf
+++ b/Missionframework/kp_liberation_config.sqf
@@ -207,7 +207,7 @@ GRLIB_halo_altitude = 5000;                                             // Altit
 GRLIB_secondary_missions_costs = [15, 10, 8];                           // Intel price for the secondary missions [FOB hunting, Convoy ambush, SAR].
 GRLIB_secondary_objective_impact = 0.8;                                 // The percentage impact against enemy combat readiness for a successful FOB hunt.
 GRLIB_recycling_percentage = 1.0;                                       // Percentage of resources you get back from recycling.
-KP_liberation_production_interval = 30;                                 // Time in minutes until a production process is finished, when resources multiplier is set to 1.
+KP_liberation_production_interval = 120;                                 // Time in minutes until a production process is finished, when resources multiplier is set to 1.
 
 GRLIB_sector_size = 700;                                               // Range to activate a sector.
 GRLIB_capture_size = 100;                                               // Range to capture a sector.

--- a/Missionframework/scripts/server/remotecall/add_logiTruck_remote_call.sqf
+++ b/Missionframework/scripts/server/remotecall/add_logiTruck_remote_call.sqf
@@ -8,9 +8,9 @@ private _storage_areas = (_nearfob nearobjects GRLIB_fob_range) select {(_x getV
 
 if ((count _storage_areas) == 0) exitWith {(localize "STR_LOGISTIC_CANTAFFORD") remoteExec ["hint",_clientID]; logiError = 1; _clientID publicVariableClient "logiError";};
 
-private _price_s = 100;
+private _price_s = 2000;
 private _price_a = 0;
-private _price_f = 100;
+private _price_f = 2000;
 
 if ((_price_s > _supplies) || (_price_a > _ammo) || (_price_f > _fuel)) exitWith {(localize "STR_LOGISTIC_CANTAFFORD") remoteExec ["hint",_clientID]; logiError = 1; _clientID publicVariableClient "logiError";};
 

--- a/Missionframework/ui/mission_params.hpp
+++ b/Missionframework/ui/mission_params.hpp
@@ -261,7 +261,7 @@ class Params {
         title = $STR_PARAMS_AILOGISTICS;
         values[] = {0, 1};
         texts[] = {$STR_PARAMS_DISABLED, $STR_PARAMS_ENABLED};
-        default = 0;
+        default = 1;
     };
     class CR_Building {
         title = $STR_PARAM_CR_BUILDING;


### PR DESCRIPTION
Logistics-System enabled (previous disabled), Truck-Prices set to 2000/0/2000 (previous 100/0/100), Production set to 100/4h (previous 100/1h). Note: Curret Production-Multiplier is set to x0,5 (not changed here)
Not tested.